### PR TITLE
Fix: recover on response timeout from device (#5)

### DIFF
--- a/kwii/src/kwii-command.cpp
+++ b/kwii/src/kwii-command.cpp
@@ -10,11 +10,14 @@
 #include <cstring>
 #include <unistd.h>
 #include <arpa/inet.h>
+#include <errno.h>
 #include <ros/ros.h>
 #include <std_msgs/String.h>
 #include "kwii/DevCmd.h"
 
 #define KASA_PORT 9999
+
+extern int errno;
 
 uint8_t *kasa_crypto(const uint8_t *p, int len, int enc)
 {
@@ -79,6 +82,12 @@ void command_callback(const kwii::DevCmd::ConstPtr &msg)
 		exit(1);
 	}
 
+	// Set receive timeout of 1 sec
+	struct timeval tv;
+	tv.tv_sec = 1;
+	tv.tv_usec = 0;
+	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof tv);
+
 	struct sockaddr_in sin;
 	sin.sin_family = AF_INET;
 	sin.sin_port = htons(0);
@@ -106,8 +115,18 @@ void command_callback(const kwii::DevCmd::ConstPtr &msg)
 	res = recvfrom(sock, buf, sizeof(buf), 0, (struct sockaddr *)&sin, &slen);
 	if (res == -1)
 	{
+		// Receive failed, likely due to a timeout
 		perror("recvfrom");
-		exit(1);
+		if (errno == EAGAIN)
+		{
+			// If error is "try again", reset the error and move on to the next message.
+			errno = 0;
+			return;
+		}
+		else
+		{
+			exit(1);
+		}
 	}
 
 	uint8_t *dec = kasa_decrypt((const uint8_t *)buf, res);


### PR DESCRIPTION
Added a timeout to the `recvfrom` call. This means that if a receive fails with an error value of `EAGAIN` (try again), then the error will be cleared and the command will be skipped.

This primarily solves the issue with HS105 plugs in #5. I chose to skip the command rather than resend it because of the possibility that too many messages could build up over time and just make the problem worse.